### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "express": "^4.16.4",
     "cors": "^2.8.5"
   },
-  "engines": {
-    "node": "12.0.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/freeCodeCamp/boilerplate-project-filemetadata"


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365